### PR TITLE
프로토타입 오류 정정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ReScript React Starter
 - GitHub: [ReScript React starter-kit](https://github.com/DavidYang2149/rescript-react-starter)
-- npm: [Download](https://www.npmjs.com/package/@davidyang2149/rescript-react-starter)
+- npm: [Download](https://www.npmjs.com/package/rescript-react-starter)
 
 ## 🚀 Quick start
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "ReScript React starter kit",
   "scripts": {
-    "start": "npm run serve",
+    "start": "npm run build && npm run serve",
     "serve": "parcel serve index.html --port 8080",
     "build": "rescript",
     "clean": "rescript clean -with-deps",


### PR DESCRIPTION
- 처음에 `npm run start`을 할 경우 ReScript가 빌드되지 않으면 정상적으로 실행되지 않는 경우 발견
- 잘못된 npm 링크 주소 정정